### PR TITLE
Fix bad field numbers in AWK maths

### DIFF
--- a/server-check
+++ b/server-check
@@ -89,11 +89,13 @@ function cpu-stats () {
     done
   } > $CPUCACHE
 
-  CPUPEAK=$(awk '{printf "%2.2f %%\n",$4}' $CPUCACHE 2>/dev/null | sort -n | tail -n1)
+  # $3 here refers to %user in the sar output
+  CPUPEAK=$(awk '{printf "%2.2f %%\n",$3}' $CPUCACHE 2>/dev/null | sort -n | tail -n1)
   if [ "$CPUPEAK" == "" ]; then CPUPEAK="Unknown"; fi
   echo "Peak CPU Usage   : $CPUPEAK" ;
 
-  CPUAVG=$(awk '{SUM+=$4} END {printf "%2.2f %%\n", SUM/NR}' $CPUCACHE 2>/dev/null)
+  # $3 here refers to %user in the sar output
+  CPUAVG=$(awk '{SUM+=$3} END {printf "%2.2f %%\n", SUM/NR}' $CPUCACHE 2>/dev/null)
   if [ "$CPUAVG" == "" ]; then CPUAVG="Unknown"; fi
   echo "Avg. CPU Usage   : $CPUAVG" ;
 
@@ -121,11 +123,11 @@ function ram-stats () {
     done
   } > $RAMCACHE
 
-  RAMPEAK=$(awk '{printf "%2.2f %%\n",100*(($4-$6-$7)/($3+$4))}' $RAMCACHE 2>/dev/null| sort -n | tail -n1)
+  RAMPEAK=$(awk '{printf "%2.2f %%\n",100*(($3-$5-$6)/($2+$3))}' $RAMCACHE 2>/dev/null| sort -n | tail -n1)
   if [ "$RAMPEAK" == "" ]; then RAMPEAK="Unknown"; fi
   echo "Peak RAM Usage   : $RAMPEAK" ;
 
-  RAMAVG=$(awk '{SUM+=100*(($4-$6-$7)/($3+$4))} END {printf "%2.2f %%\n",SUM/NR}' $RAMCACHE 2>/dev/null)
+  RAMAVG=$(awk '{SUM+=100*(($3-$5-$6)/($2+$3))} END {printf "%2.2f %%\n",SUM/NR}' $RAMCACHE 2>/dev/null)
   if [ "$RAMAVG" == "" ]; then RAMAVG="Unknown"; fi
   echo "Avg. RAM Usage   : $RAMAVG" ;
 


### PR DESCRIPTION
I think the maths here was wrong. I'm not sure how that crept in, but it didn't
work on CentOS 7 - I'd appreciate a second pair of eyes!

The format of `sar` is:

```
1               2       3         4       5         6          7          8
11:50:01        CPU     %user     %nice   %system   %iowait    %steal     %idle
12:00:01        all      0.34      0.00      0.35      0.00      0.00     99.30
```

As this was running before, it was finding the peak and average of field 4,
which is `%nice` when I think it's supposed to be `%user`.

The format of `sar -r` is:

```
1           2         3          4        5          6         7
19:20:01    kbmemfree kbmemused  %memused kbbuffers  kbcached  kbcommit
19:30:01        86992    415184     82.68      1424    252900    290624
```

As it was running before it was doing 100*(%memused-kbcached-kbcommit)/(kbmemused+%memused)
whereas it should be doing 100*(used-cached-buffers)/(free+used) which is
basically one field left of what it has been doing.

I'm not sure how I messed this up, unless on some other RHEL version the output
of `sar` is different and I don't have RHEL5 or RHEL6 systems to test.
