### PR TITLE
Add support for Ubuntu

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,15 +5,15 @@
 VAGRANTFILE_API_VERSION = "2"
 
 if !ENV['VAGRANT_OS']
-  abort("Please set VAGRANT_OS env var to redhat or debian")
+  abort("VAGRANT_OS environment variable not specified. Supported values: 'debian', 'redhat', 'ubuntu'")
 end
 
 if ENV['VAGRANT_OS'].downcase == "redhat"
   box_name = "puppetlabs/centos-7.0-64-nocm"
-elsif ENV['VAGRANT_OS'].downcase == "debian"
+elsif ENV['VAGRANT_OS'].downcase == "debian" || ENV['VAGRANT_OS'].downcase == "ubuntu"
   box_name = "puppetlabs/ubuntu-14.04-64-nocm"
 else
-  abort("Please set VAGRANT_OS env var to redhat or debian")
+  abort("VAGRANT_OS environment variable not specified. Supported values: 'debian', 'redhat', 'ubuntu'")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
Whilst technically Ubuntu is a Debian derivative, given that Vagrant box
being used is actually Ubuntu, it seems appropriate to allow the box to be
referenced by the distro that it actually is.

Ubuntu is popular enough that it warrants inclusion, I think.
